### PR TITLE
Rename module to github.com/grafana/gomemcache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bradfitz/gomemcache
+module github.com/grafana/gomemcache
 
 go 1.12


### PR DESCRIPTION
The upstream repo [github.com/bradfitz/gomemcache](https://github.com/bradfitz/gomemcache) looks stale, the last commit was made 1.5 months ago, and commit before the last one was made almost 1 year ago. Open PRs are waiting for review for a long time.

I suggest moving to grafana fork as a main dependency in repos where this dependency is used to get rid of replacement directives.
For example loki: https://github.com/grafana/loki/blob/9d5665e34aba3fb01cd17aa5c16c562af0ea8a06/go.mod#L324. This replacement is there for more than 2 years