### PR TITLE
Add MinIdleConnsHeadroom support

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -152,7 +152,7 @@ type Client struct {
 	Timeout time.Duration
 
 	// MinIdleConnsHeadroomPercentage specifies the percentage of minimum number of idle connections
-	// that should be kept open, compared to the number of recently used connections.
+	// that should be kept open, compared to the number of free but recently used connections.
 	// If there are idle connections but none of them has been recently used, then all idle
 	// connections get closed.
 	//

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -176,7 +176,8 @@ type Client struct {
 
 	// closed channel gets closed once the Client.Close() is called. Once closed,
 	// resources should be released.
-	closed chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
 
 	selector ServerSelector
 
@@ -287,7 +288,9 @@ func (c *Client) maxIdleConns() int {
 }
 
 func (c *Client) Close() {
-	close(c.closed)
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
 }
 
 func (c *Client) releaseIdleConnectionsUntilClosed() {

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
-
 	"strconv"
 	"strings"
 	"sync"
@@ -70,6 +70,15 @@ const (
 	// DefaultMaxIdleConns is the default maximum number of idle connections
 	// kept for any single address.
 	DefaultMaxIdleConns = 2
+
+	// releaseIdleConnsCheckFrequency is how frequently to check if there are idle
+	// connections to release, in order to honor the configured min conns headroom.
+	releaseIdleConnsCheckFrequency = time.Minute
+
+	// defaultRecentlyUsedConnsThreshold is the default grace period given to an
+	// idle connection to consider it "recently used". The default value has been
+	// set equal to the default TCP TIME_WAIT timeout in linux.
+	defaultRecentlyUsedConnsThreshold = 2 * time.Minute
 )
 
 const buffered = 8 // arbitrary buffered channel size, for readability
@@ -126,7 +135,11 @@ func New(server ...string) *Client {
 
 // NewFromSelector returns a new Client using the provided ServerSelector.
 func NewFromSelector(ss ServerSelector) *Client {
-	return &Client{selector: ss}
+	c := &Client{selector: ss, closed: make(chan struct{})}
+
+	go c.releaseIdleConnectionsUntilClosed()
+
+	return c
 }
 
 // Client is a memcache client.
@@ -138,6 +151,14 @@ type Client struct {
 	// If zero, DefaultTimeout is used.
 	Timeout time.Duration
 
+	// MinIdleConnsHeadroom specifies the percentage of minimum number of idle connections
+	// that should be kept open, compared to the number of recently used connections.
+	// If there are idle connections but none of them has been recently used, then all idle
+	// connections get closed.
+	//
+	// If the configured value is 0, idle connections are never closed.
+	MinIdleConnsHeadroom float64
+
 	// MaxIdleConns specifies the maximum number of idle connections that will
 	// be maintained per address. If less than one, DefaultMaxIdleConns will be
 	// used.
@@ -145,6 +166,17 @@ type Client struct {
 	// Consider your expected traffic rates and latency carefully. This should
 	// be set to a number higher than your peak parallel requests.
 	MaxIdleConns int
+
+	// recentlyUsedConnsThreshold is the default grace period given to an
+	// idle connection to consider it "recently used". Recently used connections
+	// are never closed even if idle.
+	//
+	// This field is used for testing.
+	recentlyUsedConnsThreshold time.Duration
+
+	// closed channel gets closed once the Client.Close() is called. Once closed,
+	// resources should be released.
+	closed chan struct{}
 
 	selector ServerSelector
 
@@ -179,6 +211,10 @@ type conn struct {
 	rw   *bufio.ReadWriter
 	addr net.Addr
 	c    *Client
+
+	// The timestamp since when this connection is idle. This is used to gradually
+	// close idle connections over time.
+	idleSince time.Time
 }
 
 // release returns this connection back to the client's free pool
@@ -213,6 +249,8 @@ func (c *Client) putFreeConn(addr net.Addr, cn *conn) {
 		cn.nc.Close()
 		return
 	}
+
+	cn.idleSince = time.Now()
 	c.freeconn[addr.String()] = append(freelist, cn)
 }
 
@@ -226,6 +264,9 @@ func (c *Client) getFreeConn(addr net.Addr) (cn *conn, ok bool) {
 	if !ok || len(freelist) == 0 {
 		return nil, false
 	}
+
+	// Pop the connection from the end of the list. This way we prefer to always reuse
+	// the same connections, so that the min idle connections logic is effective.
 	cn = freelist[len(freelist)-1]
 	c.freeconn[addr.String()] = freelist[:len(freelist)-1]
 	return cn, true
@@ -238,11 +279,89 @@ func (c *Client) netTimeout() time.Duration {
 	return DefaultTimeout
 }
 
+func (c *Client) minIdleConnsHeadroom() float64 {
+	if c.MinIdleConnsHeadroom < 0 || c.MinIdleConnsHeadroom >= 1 {
+		return 0
+	}
+
+	return c.MinIdleConnsHeadroom
+}
+
 func (c *Client) maxIdleConns() int {
 	if c.MaxIdleConns > 0 {
 		return c.MaxIdleConns
 	}
 	return DefaultMaxIdleConns
+}
+
+func (c *Client) Close() {
+	close(c.closed)
+}
+
+func (c *Client) releaseIdleConnectionsUntilClosed() {
+	for {
+		select {
+		case <-time.After(releaseIdleConnsCheckFrequency):
+			c.releaseIdleConnections()
+		case <-c.closed:
+			return
+		}
+	}
+}
+
+func (c *Client) releaseIdleConnections() {
+	var toClose []io.Closer
+
+	// Nothing to do if min idle connections headroom is disabled (zero value).
+	minIdleHeadroom := c.minIdleConnsHeadroom()
+	if minIdleHeadroom <= 0 {
+		return
+	}
+
+	// Get the recently used connections threshold, falling back to the default one.
+	recentlyUsedThreshold := c.recentlyUsedConnsThreshold
+	if recentlyUsedThreshold == 0 {
+		recentlyUsedThreshold = defaultRecentlyUsedConnsThreshold
+	}
+
+	c.lk.Lock()
+
+	for addr, freeConnections := range c.freeconn {
+		numIdle := 0
+
+		// Count the number of idle connections. Since the least used connections are at the beginning
+		// of the list, we can stop searching as soon as we find a non-idle connection.
+		for _, freeConn := range freeConnections {
+			if time.Since(freeConn.idleSince) < recentlyUsedThreshold {
+				break
+			}
+
+			numIdle++
+		}
+
+		// Compute the number of connections to close, honoring two properties:
+		// 1. Keep a number of idle connections equal to the configured headroom.
+		// 2. Keep at least 1 idle connection.
+		numRecentlyUsed := len(freeConnections) - numIdle
+		numIdleToKeep := int(math.Max(1, math.Ceil(float64(numRecentlyUsed)*minIdleHeadroom)))
+		numIdleToClose := len(freeConnections) - numRecentlyUsed - numIdleToKeep
+		if numIdleToClose <= 0 {
+			continue
+		}
+
+		// Close idle connections.
+		for i := 0; i < numIdleToClose; i++ {
+			toClose = append(toClose, freeConnections[i].nc)
+		}
+		c.freeconn[addr] = c.freeconn[addr][numIdleToClose:]
+	}
+
+	// Release the lock and then close the connections.
+	c.lk.Unlock()
+
+	for _, freeConn := range toClose {
+		freeConn.Close()
+	}
 }
 
 // ConnectTimeoutError is the error type used when it takes

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -335,7 +335,7 @@ func (c *Client) releaseIdleConnections() {
 		// the configured headroom.
 		numRecentlyUsed := len(freeConnections) - numIdle
 		numIdleToKeep := int(math.Max(0, math.Ceil(float64(numRecentlyUsed)*minIdleHeadroomPercentage/100)))
-		numIdleToClose := len(freeConnections) - numRecentlyUsed - numIdleToKeep
+		numIdleToClose := numIdle - numIdleToKeep
 		if numIdleToClose <= 0 {
 			continue
 		}

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -212,8 +212,8 @@ type conn struct {
 	addr net.Addr
 	c    *Client
 
-	// The timestamp since when this connection is idle. This is used to gradually
-	// close idle connections over time.
+	// The timestamp since when this connection is idle. This is used to close
+	// idle connections.
 	idleSince time.Time
 }
 

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -48,7 +48,11 @@ func TestLocalhost(t *testing.T) {
 	if !setup(t) {
 		return
 	}
-	testWithClient(t, New(testServer))
+
+	c := New(testServer)
+	t.Cleanup(c.Close)
+
+	testWithClient(t, c)
 }
 
 // Run the memcached binary as a child process and connect to its unix socket.
@@ -72,7 +76,10 @@ func TestUnixSocket(t *testing.T) {
 		time.Sleep(time.Duration(25*i) * time.Millisecond)
 	}
 
-	testWithClient(t, New(sock))
+	c := New(sock)
+	t.Cleanup(c.Close)
+
+	testWithClient(t, c)
 }
 
 func mustSetF(t *testing.T, c *Client) func(*Item) {
@@ -297,6 +304,158 @@ func testTouchWithClient(t *testing.T, c *Client) {
 	}
 }
 
+func TestClient_releaseIdleConnections(t *testing.T) {
+	const recentlyUsedThreshold = 2 * time.Second
+
+	getClientWithMinIdleConnsHeadroom := func(t *testing.T, headroom float64) *Client {
+		c := New(testServer)
+		t.Cleanup(c.Close)
+		c.MinIdleConnsHeadroom = headroom
+		c.MaxIdleConns = 100
+		c.recentlyUsedConnsThreshold = recentlyUsedThreshold
+
+		return c
+	}
+
+	getConn := func(c *Client) *conn {
+		addr, err := c.selector.PickServer("test")
+		if err != nil {
+			t.Fatalf("unexpected error picking server: %v", err.Error())
+		}
+
+		connection, err := c.getConn(addr)
+		if err != nil {
+			t.Fatalf("unexpected error getting connection: %v", err.Error())
+		}
+
+		return connection
+	}
+
+	countFreeConns := func(c *Client) (recentlyUsed, idle int) {
+		c.lk.Lock()
+		defer c.lk.Unlock()
+
+		for _, freeConnections := range c.freeconn {
+			for _, freeConn := range freeConnections {
+				if time.Since(freeConn.idleSince) >= c.recentlyUsedConnsThreshold {
+					idle++
+				} else {
+					recentlyUsed++
+				}
+			}
+		}
+
+		return
+	}
+
+	t.Run("noop if there are no free connections", func(t *testing.T) {
+		c := getClientWithMinIdleConnsHeadroom(t, 0.5)
+		c.releaseIdleConnections()
+
+		numRecentlyUsed, numIdle := countFreeConns(c)
+		if numRecentlyUsed != 0 {
+			t.Fatalf("expected %d recently used connections but got %d", 0, numRecentlyUsed)
+		}
+		if numIdle != 0 {
+			t.Fatalf("expected %d idle connections but got %d", 0, numIdle)
+		}
+	})
+
+	t.Run("should not release recently used connections", func(t *testing.T) {
+		c := getClientWithMinIdleConnsHeadroom(t, 0.5)
+
+		conn1 := getConn(c)
+		conn2 := getConn(c)
+		conn1.release()
+		conn2.release()
+
+		c.releaseIdleConnections()
+
+		numRecentlyUsed, numIdle := countFreeConns(c)
+		if numRecentlyUsed != 2 {
+			t.Fatalf("expected %d recently used connections but got %d", 2, numRecentlyUsed)
+		}
+		if numIdle != 0 {
+			t.Fatalf("expected %d idle connections but got %d", 0, numIdle)
+		}
+	})
+
+	t.Run("should release idle connections while honoring the configured headroom", func(t *testing.T) {
+		c := getClientWithMinIdleConnsHeadroom(t, 0.5)
+
+		conn1 := getConn(c)
+		conn2 := getConn(c)
+		conn3 := getConn(c)
+		conn4 := getConn(c)
+
+		conn1.release()
+		conn2.release()
+		time.Sleep(recentlyUsedThreshold)
+		conn3.release()
+		conn4.release()
+
+		c.releaseIdleConnections()
+
+		numRecentlyUsed, numIdle := countFreeConns(c)
+		if numRecentlyUsed != 2 {
+			t.Fatalf("expected %d recently used connections but got %d", 2, numRecentlyUsed)
+		}
+		if numIdle != 1 {
+			t.Fatalf("expected %d idle connections but got %d", 1, numIdle)
+		}
+	})
+
+	t.Run("should not release idle connections if headroom is disabled (zero)", func(t *testing.T) {
+		c := getClientWithMinIdleConnsHeadroom(t, 0)
+
+		conn1 := getConn(c)
+		conn2 := getConn(c)
+		conn3 := getConn(c)
+		conn4 := getConn(c)
+
+		conn1.release()
+		conn2.release()
+		time.Sleep(recentlyUsedThreshold)
+		conn3.release()
+		conn4.release()
+
+		c.releaseIdleConnections()
+
+		numRecentlyUsed, numIdle := countFreeConns(c)
+		if numRecentlyUsed != 2 {
+			t.Fatalf("expected %d recently used connections but got %d", 2, numRecentlyUsed)
+		}
+		if numIdle != 2 {
+			t.Fatalf("expected %d idle connections but got %d", 2, numIdle)
+		}
+	})
+
+	t.Run("should not release idle connections if headroom is 100%", func(t *testing.T) {
+		c := getClientWithMinIdleConnsHeadroom(t, 1)
+
+		conn1 := getConn(c)
+		conn2 := getConn(c)
+		conn3 := getConn(c)
+		conn4 := getConn(c)
+
+		conn1.release()
+		conn2.release()
+		time.Sleep(recentlyUsedThreshold)
+		conn3.release()
+		conn4.release()
+
+		c.releaseIdleConnections()
+
+		numRecentlyUsed, numIdle := countFreeConns(c)
+		if numRecentlyUsed != 2 {
+			t.Fatalf("expected %d recently used connections but got %d", 2, numRecentlyUsed)
+		}
+		if numIdle != 2 {
+			t.Fatalf("expected %d idle connections but got %d", 2, numIdle)
+		}
+	})
+}
+
 func BenchmarkOnItem(b *testing.B) {
 	fakeServer, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -315,6 +474,8 @@ func BenchmarkOnItem(b *testing.B) {
 
 	addr := fakeServer.Addr()
 	c := New(addr.String())
+	b.Cleanup(c.Close)
+
 	if _, err := c.getConn(addr); err != nil {
 		b.Fatal("failed to initialize connection to fake server")
 	}

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -506,6 +506,14 @@ func TestClient_releaseIdleConnections(t *testing.T) {
 	})
 }
 
+func TestClient_Close_ShouldBeIdempotent(t *testing.T) {
+	c := New(testServer)
+
+	// Call Close twice and make sure it doesn't panic the 2nd time.
+	c.Close()
+	c.Close()
+}
+
 func BenchmarkOnItem(b *testing.B) {
 	fakeServer, err := net.Listen("tcp", "localhost:0")
 	if err != nil {


### PR DESCRIPTION
Currently memcached client allows to configure the max number of idle connections. These idle connections are never closed, even if unused for a long time. There's some tensions on the value you set for idle connections:
- Too low: new connections are opened for each Get operation when your concurrency is > max idle connections
- Too high: a short spike in Get concurrency will open new connections which then are kept idle until the process restarts even if unused

In this PR I'm proposing to add a `MinIdleConnsHeadroom` config option. When configured, the client periodically closes idle connections up until `MinIdleConnsHeadroom` percentage of the recently used connections. If `MinIdleConnsHeadroom` is not configured (zero value) there's no difference compared to previous version.

In order to periodically close the connections, the client now runs a maintenance goroutine. The client goroutine can be stopped calling the new `Close()` function.

_Other the new unit tests, I've manually tested it in Mimir (see https://github.com/grafana/mimir/pull/4249) and looks working as designed._