### PR TITLE
Remove Prometheus instrumentation added in #12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,3 @@
 module github.com/grafana/gomemcache
 
 go 1.18
-
-require github.com/prometheus/client_golang v1.15.0
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.42.0 // indirect
-	github.com/prometheus/procfs v0.9.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
-)


### PR DESCRIPTION
The instrumentation adds a dependency on the Prometheus client and didn't end up being used by Loki (or any other database). Removing so this client can be used with only the standard library.

Related #12