### PR TITLE
Allocate map for results to hold expected number of keys

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -619,7 +619,7 @@ func (c *Client) GetMulti(keys []string, opts ...Option) (map[string]*Item, erro
 	options := newOptions(opts...)
 
 	var lk sync.Mutex
-	m := make(map[string]*Item)
+	m := make(map[string]*Item, len(keys))
 	addItemToMap := func(it *Item) {
 		lk.Lock()
 		defer lk.Unlock()


### PR DESCRIPTION
Pre-allocate the map used for results based on the number of keys being fetched. Not needing to grow the map as items are added results in a 5-10% performance improvement in local benchmarking. Tested with a local instance of `memcached 1.6.14`

```
$ go test -cpu=1,2,4 -run=XXX -benchmem -bench=BenchmarkGetMulti ./... | tee old.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/gomemcache/memcache
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkGetMulti          12399             95828 ns/op           47040 B/op        426 allocs/op
BenchmarkGetMulti-2         9954            101181 ns/op           47053 B/op        426 allocs/op
BenchmarkGetMulti-4        10000            101635 ns/op           47060 B/op        426 allocs/op
PASS
ok      github.com/grafana/gomemcache/memcache  4.245s
```

```
$ go test -cpu=1,2,4 -run=XXX -benchmem -bench=BenchmarkGetMulti ./... | tee new.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/gomemcache/memcache
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkGetMulti          13216             90229 ns/op           39241 B/op        420 allocs/op
BenchmarkGetMulti-2        12792             93448 ns/op           39247 B/op        420 allocs/op
BenchmarkGetMulti-4        12559             94620 ns/op           39258 B/op        420 allocs/op
PASS
ok      github.com/grafana/gomemcache/memcache  6.436s
```

```
benchstat -delta-test none old.txt new.txt 
name        old time/op    new time/op    delta
GetMulti      95.8µs ± 0%    90.2µs ± 0%   -5.84%
GetMulti-2     101µs ± 0%      93µs ± 0%   -7.64%
GetMulti-4     102µs ± 0%      95µs ± 0%   -6.90%

name        old alloc/op   new alloc/op   delta
GetMulti      47.0kB ± 0%    39.2kB ± 0%  -16.58%
GetMulti-2    47.1kB ± 0%    39.2kB ± 0%  -16.59%
GetMulti-4    47.1kB ± 0%    39.3kB ± 0%  -16.58%

name        old allocs/op  new allocs/op  delta
GetMulti         426 ± 0%       420 ± 0%   -1.41%
GetMulti-2       426 ± 0%       420 ± 0%   -1.41%
GetMulti-4       426 ± 0%       420 ± 0%   -1.41%
```