### PR TITLE
Revert "Merge pull request #18 from grafana/mmandrus/client-reconnect"

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -20,7 +20,6 @@ package memcache
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -80,10 +79,6 @@ const (
 	// idle connection to consider it "recently used". The default value has been
 	// set equal to the default TCP TIME_WAIT timeout in linux.
 	defaultRecentlyUsedConnsThreshold = 2 * time.Minute
-
-	// defaultReconnectCronTimeout is how often the client will attempt to reestablish
-	// connection to the server when initialized with NewWithBackgroundReconnect
-	defaultReconnectCronTimeout = 10 * time.Minute
 )
 
 const buffered = 8 // arbitrary buffered channel size, for readability
@@ -135,35 +130,7 @@ var (
 func New(server ...string) *Client {
 	ss := new(ServerList)
 	_ = ss.SetServers(server...)
-	c := NewFromSelector(ss)
-	c.serverList = append(c.serverList, server...)
-
-	return c
-}
-
-// NewWithBackgroundReconnect returns the same thing as New(server ...string), but takes a context and timeout to initiate a bakground reconnect cron
-func NewWithBackgroundReconnect(ctx context.Context, interval time.Duration, server ...string) *Client {
-	c := New(server...)
-
-	if interval == 0 {
-		interval = defaultReconnectCronTimeout
-	}
-	ticker := time.NewTicker(interval)
-
-	// periodically ping the provided servers -- if there are timeouts, it will trigger a reconnect attempt
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				_ = c.Ping()
-			}
-		}
-	}()
-
-	return c
+	return NewFromSelector(ss)
 }
 
 // NewFromSelector returns a new Client using the provided ServerSelector.
@@ -232,9 +199,6 @@ type Client struct {
 
 	lk       sync.Mutex
 	freeconn map[string][]*conn
-
-	serverList    []string
-	reconnectLock sync.Mutex
 }
 
 // Item is an item to be got or stored in a memcached server.
@@ -439,9 +403,6 @@ func (c *Client) dial(addr net.Addr) (net.Conn, error) {
 	}
 
 	if ne, ok := err.(net.Error); ok && ne.Timeout() {
-		// In the case of a timeout, we might need to reestablish a connection to one or more servers, for example in case of an IP change
-		// Fire this off in a goroutine so it doesn't delay a response back to the client
-		c.backgroundReconnect()
 		return nil, &ConnectTimeoutError{addr}
 	}
 
@@ -459,7 +420,6 @@ func (c *Client) getConn(addr net.Addr) (*conn, error) {
 		cn.extendDeadline()
 		return cn, nil
 	}
-
 	nc, err := c.dial(addr)
 	if err != nil {
 		return nil, err
@@ -958,27 +918,4 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 		return nil
 	})
 	return val, err
-}
-
-// backgroundReconnect makes an asyncronous attempt to reconnect to the provided server list and reset all open connections
-func (c *Client) backgroundReconnect() {
-	go func() {
-		c.reconnectLock.Lock()
-		defer c.reconnectLock.Unlock()
-
-		if sl, ok := c.selector.(*ServerList); ok {
-			if err := sl.SetServers(c.serverList...); err == nil {
-				c.lk.Lock()
-				defer c.lk.Unlock()
-
-				// close all open connections before deleting them
-				for _, cs := range c.freeconn {
-					for _, conn := range cs {
-						conn.nc.Close()
-					}
-				}
-				c.freeconn = make(map[string][]*conn)
-			}
-		}
-	}()
 }


### PR DESCRIPTION
This reverts the change to attempt to reconnect within this client. The motivation for this is to avoid spawning a new goroutine when there are connection errors. Similar functionality exists in the wrapper of this client in dskit which automatically re-resolves servers every 30 seconds and updates the selector's list of servers.

This reverts commit fdaf6a95408eab4f992f047f7f037b32d9927f3b, reversing changes made to e553a78ea238794b71fa2ced9ba64b157465fb70.