### PR TITLE
Require go 1.21 instead of 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/grafana/gomemcache
 
-go 1.22
+go 1.21


### PR DESCRIPTION
This matches the minimum supported version in dskit