### PR TITLE
Pin all github actions to a commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.22
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: 1.22
-
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Install Memcached
         run: sudo apt-get install -y memcached
       - name: Run Tests
@@ -23,14 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.22
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: 1.22
-
       - name: Check out code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: v1.59.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
           go-version: 1.22
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
       - name: Install Memcached
         run: sudo apt-get install -y memcached
       - name: Run Tests
@@ -27,6 +29,8 @@ jobs:
           go-version: 1.22
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:


### PR DESCRIPTION
This updates github actions used by CI to specific commits instead of floating tags. The following changes were made:

* `actions/setup-go` Updated to `0aaccfd150d50ccaeb58ebd88d36e91967a5f35b`, `v5.4.0` from `v5`
* `actions/checkout` Updated to `11bd71901bbe5b1630ceea73d27597364c9af683`, `v4.2.2` from `v4`
* `golangci/golangci-lint-action` Updated to `55c2c1448f86e01eaae002a5a3a9624417608d84`, `v.6.5.2` from `v6`