### PR TITLE
GetMulti: Wait for allocations to finish before returning

### DIFF
--- a/memcache/line_reader.go
+++ b/memcache/line_reader.go
@@ -1,0 +1,79 @@
+package memcache
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+)
+
+type lineReader interface {
+	ReadLine(from io.Reader, lineLength int) ([]byte, error)
+}
+
+type allocatingLineReader struct {
+	allocator Allocator
+}
+
+func (s allocatingLineReader) ReadLine(from io.Reader, lineLength int) ([]byte, error) {
+	// Get can return a larger buffer than requested, but never smaller.
+	// So we need to save how much of it we actually use.
+	// Expect the line to end with \r\n, so read 2 extra bytes.
+	readSize := lineLength + 2
+	buff := s.allocator.Get(readSize)
+
+	destBuf := (*buff)[:readSize]
+	_, err := io.ReadFull(from, destBuf)
+	if err != nil {
+		s.allocator.Put(buff)
+		return nil, fmt.Errorf("failed to read line: %w", err)
+	}
+	if !bytes.HasSuffix(destBuf, crlf) {
+		s.allocator.Put(buff)
+		return nil, fmt.Errorf("line is not followed by CRLF")
+	}
+	return destBuf[:lineLength], nil
+}
+
+type noopLineReader struct{}
+
+func (s noopLineReader) ReadLine(from io.Reader, lineLength int) ([]byte, error) {
+	_, err := io.CopyN(io.Discard, from, int64(lineLength))
+	if err != nil {
+		return nil, fmt.Errorf("discarding line: %w", err)
+	}
+	return nil, nil
+}
+
+func tryDiscardLines(r *bufio.Reader) error {
+	for {
+		_, err := readLine(r, noopLineReader{})
+		if errors.Is(err, io.EOF) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("memcache GetMulti: discarding cancelled response: %w", err)
+		}
+	}
+	return nil
+}
+
+func readLine[R lineReader](r *bufio.Reader, buff R) (*Item, error) {
+	line, err := r.ReadSlice('\n')
+	if err != nil {
+		return nil, err
+	}
+	if bytes.Equal(line, resultEnd) {
+		return nil, io.EOF
+	}
+	it := new(Item)
+	size, err := scanGetResponseLine(line, it)
+	if err != nil {
+		return nil, err
+	}
+	it.Value, err = buff.ReadLine(r, size)
+	if err != nil {
+		return nil, fmt.Errorf("memcache: corrupt get result: %w", err)
+	}
+	return it, nil
+}

--- a/memcache/line_reader.go
+++ b/memcache/line_reader.go
@@ -55,7 +55,6 @@ func tryDiscardLines(r *bufio.Reader) error {
 			return fmt.Errorf("memcache GetMulti: discarding cancelled response: %w", err)
 		}
 	}
-	return nil
 }
 
 func readLine[R lineReader](r *bufio.Reader, buff R) (*Item, error) {

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -640,11 +640,9 @@ func (c *Client) GetMulti(ctx context.Context, keys []string, opts ...Option) (m
 
 	var err error
 	for i := 0; i < len(keyMap); i++ {
-		select {
-		case ge := <-ch:
-			if ge != nil {
-				err = ge
-			}
+		ge := <-ch
+		if ge != nil {
+			err = ge
 		}
 	}
 	return m, err

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -645,6 +645,9 @@ func (c *Client) GetMulti(ctx context.Context, keys []string, opts ...Option) (m
 			err = ge
 		}
 	}
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("memcache GetMulti: %w", ctx.Err())
+	}
 	return m, err
 }
 

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -634,10 +634,7 @@ func (c *Client) GetMulti(ctx context.Context, keys []string, opts ...Option) (m
 	ch := make(chan error, buffered)
 	for addr, keys := range keyMap {
 		go func(addr net.Addr, keys []string) {
-			err := c.getFromAddr(ctx, addr, keys, options, addItemToMap)
-			select {
-			case ch <- err:
-			}
+			ch <- c.getFromAddr(ctx, addr, keys, options, addItemToMap)
 		}(addr, keys)
 	}
 

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -66,7 +66,7 @@ var (
 
 const (
 	// DefaultTimeout is the default socket read/write timeout.
-	DefaultTimeout = 1000 * time.Millisecond
+	DefaultTimeout = 100 * time.Millisecond
 
 	// DefaultMaxIdleConns is the default maximum number of idle connections
 	// kept for any single address.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -665,7 +665,7 @@ func (c *Client) parseGetResponse(ctx context.Context, r *bufio.Reader, conn *co
 			if err != nil {
 				return fmt.Errorf("memcache GetMulti: %w %w", ctx.Err(), err)
 			}
-			return fmt.Errorf("memcache GetMulti: %w", ctx.Err())
+			return nil
 		default:
 		}
 

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -666,7 +666,11 @@ func (c *Client) parseGetResponse(ctx context.Context, r *bufio.Reader, conn *co
 			// Try to discard the rest of the response to keep the connection in a good state
 			// We don't want to block forever here, so use a longer deadline than usual, but don't renew it on every item read.
 			conn.extendDeadlineLong()
-			return tryDiscardLines(r)
+			err := tryDiscardLines(r)
+			if err != nil {
+				return fmt.Errorf("memcache GetMulti: %w %w", ctx.Err(), err)
+			}
+			return fmt.Errorf("memcache GetMulti: %w", ctx.Err())
 		default:
 		}
 

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -28,13 +28,23 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func repeat[T any](slice []T, count int) []T {
+	if count <= 0 {
+		return nil
+	}
+	result := make([]T, 0, len(slice)*count)
+	for i := 0; i < count; i++ {
+		result = append(result, slice...)
+	}
+	return result
+}
 
 const testServer = "localhost:11211"
 
@@ -207,7 +217,7 @@ func testWithClient(t *testing.T, c *Client) {
 		mustSet(&Item{Key: "large1", Value: make([]byte, 1000)})
 
 		// Fetch more keys to increase the chance of the cancellation happening during fetching.
-		requestedKeys := slices.Repeat([]string{"large1"}, 1000)
+		requestedKeys := repeat([]string{"large1"}, 1000)
 
 		var avgRequestDuration time.Duration
 		{

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -733,7 +733,6 @@ func BenchmarkParseGetResponse(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		opts.doneWithAlloc.Add(1)
 		err := c.parseGetResponse(context.Background(), reader, cn, opts, func(it *Item) {
 			opts.Alloc.Put(&it.Value)
 		})

--- a/memcache/options.go
+++ b/memcache/options.go
@@ -1,13 +1,10 @@
 package memcache
 
-import "sync"
-
 var nopAllocator = &defaultAllocator{}
 
 func newOptions(opts ...Option) *Options {
 	o := &Options{
-		Alloc:         nopAllocator,
-		doneWithAlloc: &sync.WaitGroup{},
+		Alloc: nopAllocator,
 	}
 
 	for _, opt := range opts {
@@ -22,8 +19,6 @@ func newOptions(opts ...Option) *Options {
 // passed to a Client method to a default Options instance.
 type Options struct {
 	Alloc Allocator
-
-	doneWithAlloc *sync.WaitGroup
 }
 
 // Option is a callback used to modify the Options that a particular Client

--- a/memcache/options.go
+++ b/memcache/options.go
@@ -1,10 +1,13 @@
 package memcache
 
+import "sync"
+
 var nopAllocator = &defaultAllocator{}
 
 func newOptions(opts ...Option) *Options {
 	o := &Options{
-		Alloc: nopAllocator,
+		Alloc:         nopAllocator,
+		doneWithAlloc: &sync.WaitGroup{},
 	}
 
 	for _, opt := range opts {
@@ -19,6 +22,8 @@ func newOptions(opts ...Option) *Options {
 // passed to a Client method to a default Options instance.
 type Options struct {
 	Alloc Allocator
+
+	doneWithAlloc *sync.WaitGroup
 }
 
 // Option is a callback used to modify the Options that a particular Client


### PR DESCRIPTION
we found a bug in mimir where we don't expect GetMulti to be allocating after it returns. This PR fixes that. follow-up of #26


This makes ParseGetResponse a little bit slower
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/gomemcache/memcache
cpu: Apple M1 Pro
                    │ scratch_24.txt │           scratch_23.txt           │
                    │     sec/op     │   sec/op     vs base               │
ParseGetResponse-10      406.5n ± 0%   434.7n ± 0%  +6.92% (p=0.000 n=10)

                    │ scratch_24.txt │         scratch_23.txt         │
                    │      B/op      │    B/op     vs base            │
ParseGetResponse-10       88.00 ± 0%   88.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                    │ scratch_24.txt │         scratch_23.txt         │
                    │   allocs/op    │ allocs/op   vs base            │
ParseGetResponse-10       2.000 ± 0%   2.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```