### PR TITLE
GetMulti: fix connection draining

### DIFF
--- a/memcache/line_reader.go
+++ b/memcache/line_reader.go
@@ -73,8 +73,8 @@ func readLine[R lineReader](r *bufio.Reader, buff R) (*Item, error) {
 		return nil, err
 	}
 
-	// Expect the line to end with \r\n, so read 2 extra bytes.
-	readSize := size + 2
+	// Expect the line to end with \r\n
+	readSize := size + len(crlf)
 
 	it.Value, err = buff.ReadLine(r, readSize)
 	if err != nil {

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -657,7 +657,7 @@ func TestClient_GetMulti_ContextCancelled(t *testing.T) {
 		}
 	}()
 
-	t.Run("should context canceled", func(t *testing.T) {
+	t.Run("should respect context cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		errCh := make(chan error)

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -636,6 +636,111 @@ func TestClient_releaseIdleConnections(t *testing.T) {
 	})
 }
 
+func TestClient_GetMulti_ContextCancelled(t *testing.T) {
+	clientConn, srvConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = srvConn.Close()
+		_ = clientConn.Close()
+	})
+
+	c := NewFromSelector(dummySelector{})
+	c.DialTimeout = func(string, string, time.Duration) (net.Conn, error) {
+		return clientConn, nil
+	}
+
+	srvReqs := make(chan string)
+	go func() {
+		br := bufio.NewReader(srvConn)
+		for {
+			line, _ := br.ReadSlice('\n')
+			srvReqs <- string(line)
+		}
+	}()
+
+	t.Run("should context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error)
+		go func() {
+			_, err := c.GetMulti(ctx, []string{"key1", "key2"})
+			errCh <- err
+		}()
+
+		req := <-srvReqs
+		if string(req) != "gets key1 key2\r\n" {
+			t.Fatalf("unexpected GetMulti request: got %s", string(req))
+		}
+
+		// Send only a header portion of the response, causing the client to block, waiting for the rest.
+		if _, err := io.WriteString(srvConn, "VALUE key1 0 5\r\n"); err != nil {
+			t.Fatalf("write GetMulti response header: %v", err)
+		}
+
+		// Cancel context immediately to trigger cancellation during parsing
+		cancel()
+
+		// Send the rest of the response to unblock the client and to trigger the connection draining.
+		if _, err := io.WriteString(srvConn, "abcde\r\nVALUE key2 0 3\r\nabc\r\nEND\r\n"); err != nil {
+			t.Fatalf("write GetMulti response: %v", err)
+		}
+
+		err := <-errCh
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("GetMulti with cancelled context during parsing: got err=%v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("should context canceled when conn draining fails", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error)
+		go func() {
+			_, err := c.GetMulti(ctx, []string{"key1", "key2"})
+			errCh <- err
+		}()
+
+		req := <-srvReqs
+		if string(req) != "gets key1 key2\r\n" {
+			t.Fatalf("unexpected GetMulti request: got %s", string(req))
+		}
+
+		// Send only a header portion of the response, causing the client to block, waiting for the rest.
+		if _, err := io.WriteString(srvConn, "VALUE key1 0 5\r\n"); err != nil {
+			t.Fatalf("write GetMulti response header: %v", err)
+		}
+
+		// Cancel context immediately to trigger cancellation during parsing
+		cancel()
+
+		// This chunk of the response isn't complete, because it doesn't end with "END\r\n".
+		// Draining this request will cause the connection to timeout. This shouldn't be visible to the caller, because the context was already cancelled.
+		if _, err := io.WriteString(srvConn, "abcde\r\nVALUE key2 0 3\r\n"); err != nil {
+			t.Fatalf("write GetMulti response: %v", err)
+		}
+
+		err := <-errCh
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("GetMulti with cancelled context during parsing: got err=%v, want context.Canceled", err)
+		}
+	})
+}
+
+type dummyAddr struct{}
+
+func (t dummyAddr) Network() string { return "dummy" }
+
+func (t dummyAddr) String() string { return "dummy" }
+
+type dummySelector struct{}
+
+func (d dummySelector) PickServer(string) (net.Addr, error) {
+	return dummyAddr{}, nil
+}
+
+func (d dummySelector) Each(f func(net.Addr) error) error {
+	return f(dummyAddr{})
+}
+
 func TestClient_Close_ShouldBeIdempotent(t *testing.T) {
 	c := New(testServer)
 


### PR DESCRIPTION
The PR fixes a bug introduced in #28 where the cancelled connection draining doesn't account for the `CRLF` in the end of the response line. In practice, this causes the connection to time out (or fail on parsing) and close.

The PR adds a new test, that tests the client against a fake, in-memory synchronous server. This allows us to control the periods when the client is blocked, when it parses the response.

(I don't want to remove the existing tests, that tried to test that against a real memcached)