### PR TITLE
Don't error on zero-length values

### DIFF
--- a/memcache/line_reader.go
+++ b/memcache/line_reader.go
@@ -35,15 +35,7 @@ func (s allocatingLineReader) ReadLine(from io.Reader, lineLength int) ([]byte, 
 		s.allocator.Put(buff)
 		return nil, fmt.Errorf("line is not followed by CRLF")
 	}
-
-	destBuf = destBuf[:lineLength-len(crlf)]
-	if len(destBuf) == 0 {
-		// No point in holding the buffer if the item doesn't have value. Put buf back into the pool, and reply with a zero-length slice.
-		s.allocator.Put(buff)
-		return []byte{}, nil
-	}
-
-	return destBuf, err
+	return destBuf[:lineLength-len(crlf)], nil
 }
 
 type noopLineReader struct{}

--- a/memcache/line_reader_test.go
+++ b/memcache/line_reader_test.go
@@ -2,7 +2,6 @@ package memcache
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -32,9 +31,6 @@ func BenchmarkReadLine(b *testing.B) {
 				buf.Reset(resp)
 
 				it, err := readLine(&buf, lineReader)
-				if errors.Is(err, io.EOF) {
-					continue
-				}
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -45,8 +41,8 @@ func BenchmarkReadLine(b *testing.B) {
 					b.Fatalf("unexpected value len: want %d, got %d bytes", size, len(it.Value))
 				}
 
-				// Note, the current option's promise is the Client will only call Put in the event of an error.
-				// That is, the callers *may* expect that they are allowed to Put the Value back into the pool.
+				// Note, the current option's promise is that the Client will only call Put in the event of an error.
+				// That is, the callers *may* expect that they are allowed to Put the item's Value back into the pool.
 				alloc.Put(&it.Value)
 			}
 		})

--- a/memcache/line_reader_test.go
+++ b/memcache/line_reader_test.go
@@ -1,0 +1,51 @@
+package memcache
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func BenchmarkReadLine(b *testing.B) {
+	alloc := newTestAllocator(1024 + 2) // extra 2 is for body's trailing "\r\n"
+
+	for _, size := range []int{0, 1024} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			lineReader := allocatingLineReader{
+				allocator: alloc,
+			}
+
+			resp := strings.NewReader(fmt.Sprintf("VALUE foobar 0 %v\r\n%s\r\nEND\r\n", size, strings.Repeat("a", size)))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var buf bufio.Reader
+			for i := 0; i < b.N; i++ {
+				resp.Seek(0, io.SeekStart)
+				buf.Reset(resp)
+
+				it, err := readLine(&buf, lineReader)
+				if errors.Is(err, io.EOF) {
+					continue
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+				if it.Value == nil {
+					b.Fatal("unexpected nil value")
+				}
+				if len(it.Value) != size {
+					b.Fatalf("unexpected value len: want %d, got %d bytes", size, len(it.Value))
+				}
+
+				// Note, the current option's promise is the Client will only call Put in the event of an error.
+				// That is, the callers *may* expect that they are allowed to Put the Value back into the pool.
+				alloc.Put(&it.Value)
+			}
+		})
+	}
+}

--- a/memcache/line_reader_test.go
+++ b/memcache/line_reader_test.go
@@ -25,7 +25,10 @@ func BenchmarkReadLine(b *testing.B) {
 
 			var buf bufio.Reader
 			for i := 0; i < b.N; i++ {
-				resp.Seek(0, io.SeekStart)
+				_, err := resp.Seek(0, io.SeekStart)
+				if err != nil {
+					b.Fatal(err)
+				}
 				buf.Reset(resp)
 
 				it, err := readLine(&buf, lineReader)

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -147,6 +147,26 @@ func testWithClient(t *testing.T, c *Client) {
 		}
 	})
 
+	t.Run("get and set zero-length item", func(t *testing.T) {
+		foo := &Item{Key: "zerofoo"} // memcached allows values of zero length
+		err := c.Set(foo)
+		checkErr(err, "first set(zerofoo): %v", err)
+		err = c.Set(foo)
+		checkErr(err, "second set(zerofoo): %v", err)
+
+		it, err := c.Get("zerofoo")
+		checkErr(err, "get(zerofoo): %v", err)
+		if it.Key != "zerofoo" {
+			t.Errorf("get(zerofoo) Key = %q, want zerofoo", it.Key)
+		}
+		if string(it.Value) != "" {
+			t.Errorf("get(zerofoo) Value = %q, want empty", string(it.Value))
+		}
+		if it.Flags != 0 {
+			t.Errorf("get(zerofoo) Flags = %v, want 0", it.Flags)
+		}
+	})
+
 	t.Run("set malformed keys", func(t *testing.T) {
 		malFormed := &Item{Key: "foo bar", Value: []byte("foobarval")}
 		err := c.Set(malFormed)


### PR DESCRIPTION
This is a fixup for https://github.com/grafana/gomemcache/pull/29

In the mentioned PR I added a guard, that checks the length of the memcached response, assuming the response can't be zero. It has turned out storing an item with no value is a valid case.

This PR addresses that, by handling the response from a `get` command, with `0` size.