### PR TITLE
Don't close connections on clean protocol-level SERVER_ERROR responses

### DIFF
--- a/memcache/line_reader.go
+++ b/memcache/line_reader.go
@@ -70,6 +70,11 @@ func readLine[R lineReader](r *bufio.Reader, buff R) (*Item, error) {
 	it := new(Item)
 	size, err := scanGetResponseLine(line, it)
 	if err != nil {
+		// The line is not a VALUE line: check whether it's a protocol-level
+		// server error before reporting it as unexpected.
+		if serverErr := serverErrorFromLine(line); serverErr != nil {
+			return nil, serverErr
+		}
 		return nil, err
 	}
 

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -875,9 +875,11 @@ func writeExpectf(rw *bufio.ReadWriter, expect []byte, format string, args ...in
 		return ErrCASConflict
 	case bytes.Equal(line, resultNotFound):
 		return ErrCacheMiss
-	}
-	if err := serverErrorFromLine(line); err != nil {
-		return err
+	default:
+		if err := serverErrorFromLine(line); err != nil {
+			return err
+		}
+
 	}
 	return fmt.Errorf("memcache: unexpected response line: %q", string(line))
 }

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -838,10 +838,12 @@ func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) erro
 		return ErrCASConflict
 	case bytes.Equal(line, resultNotFound):
 		return ErrCacheMiss
+	default:
+		if err := serverErrorFromLine(line); err != nil {
+			return err
+		}
 	}
-	if err := serverErrorFromLine(line); err != nil {
-		return err
-	}
+
 	return fmt.Errorf("memcache: unexpected response line from %q: %q", verb, string(line))
 }
 

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -88,6 +88,13 @@ const buffered = 8 // arbitrary buffered channel size, for readability
 // This is used to determine whether or not a server connection should
 // be re-used or not. If an error occurs, by default we don't reuse the
 // connection, unless it was just a protocol-level error.
+//
+// SERVER_ERROR replies are resumable: memcached sends them as complete,
+// well-formed lines and keeps the connection in sync (on storage errors it
+// even swallows the request's data block; see process_update_command in
+// memcached's proto_text.c). The known exception is "out of memory reading
+// request", which closes the connection server-side; reusing it costs one
+// failed request, the same as any stale pooled connection.
 func resumableError(err error) bool {
 	switch {
 	case errors.Is(err, ErrCacheMiss),
@@ -101,9 +108,7 @@ func resumableError(err error) bool {
 }
 
 // serverErrorFromLine returns an error wrapping ErrServerError if line is a
-// SERVER_ERROR response, or nil otherwise. A SERVER_ERROR response is a clean,
-// protocol-level error: the server sent a complete, well-formed reply and the
-// connection is left in a usable state, so it is safe to reuse.
+// SERVER_ERROR response, or nil otherwise.
 func serverErrorFromLine(line []byte) error {
 	if !bytes.HasPrefix(line, resultServerErrorPrefix) {
 		return nil

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -84,16 +84,32 @@ const (
 
 const buffered = 8 // arbitrary buffered channel size, for readability
 
-// resumableError returns true if err is only a protocol-level cache error.
+// resumableError returns true if err is only a protocol-level error.
 // This is used to determine whether or not a server connection should
 // be re-used or not. If an error occurs, by default we don't reuse the
-// connection, unless it was just a cache error.
+// connection, unless it was just a protocol-level error.
 func resumableError(err error) bool {
-	switch err {
-	case ErrCacheMiss, ErrCASConflict, ErrNotStored, ErrMalformedKey:
+	switch {
+	case errors.Is(err, ErrCacheMiss),
+		errors.Is(err, ErrCASConflict),
+		errors.Is(err, ErrNotStored),
+		errors.Is(err, ErrMalformedKey),
+		errors.Is(err, ErrServerError):
 		return true
 	}
 	return false
+}
+
+// serverErrorFromLine returns an error wrapping ErrServerError if line is a
+// SERVER_ERROR response, or nil otherwise. A SERVER_ERROR response is a clean,
+// protocol-level error: the server sent a complete, well-formed reply and the
+// connection is left in a usable state, so it is safe to reuse.
+func serverErrorFromLine(line []byte) error {
+	if !bytes.HasPrefix(line, resultServerErrorPrefix) {
+		return nil
+	}
+	msg := bytes.TrimSuffix(line[len(resultServerErrorPrefix):], crlf)
+	return fmt.Errorf("%w: %s", ErrServerError, msg)
 }
 
 func legalKey(key string) bool {
@@ -121,6 +137,7 @@ var (
 	resultTouched   = []byte("TOUCHED\r\n")
 
 	resultClientErrorPrefix = []byte("CLIENT_ERROR ")
+	resultServerErrorPrefix = []byte("SERVER_ERROR ")
 	versionPrefix           = []byte("VERSION")
 	valuePrefix             = []byte("VALUE ")
 )
@@ -590,6 +607,9 @@ func (c *Client) touchFromAddr(addr net.Addr, keys []string, expiration int32) e
 			case bytes.Equal(line, resultNotFound):
 				return ErrCacheMiss
 			default:
+				if err := serverErrorFromLine(line); err != nil {
+					return err
+				}
 				return fmt.Errorf("memcache: unexpected response line from touch: %q", string(line))
 			}
 		}
@@ -814,6 +834,9 @@ func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) erro
 	case bytes.Equal(line, resultNotFound):
 		return ErrCacheMiss
 	}
+	if err := serverErrorFromLine(line); err != nil {
+		return err
+	}
 	return fmt.Errorf("memcache: unexpected response line from %q: %q", verb, string(line))
 }
 
@@ -845,6 +868,9 @@ func writeExpectf(rw *bufio.ReadWriter, expect []byte, format string, args ...in
 		return ErrCASConflict
 	case bytes.Equal(line, resultNotFound):
 		return ErrCacheMiss
+	}
+	if err := serverErrorFromLine(line); err != nil {
+		return err
 	}
 	return fmt.Errorf("memcache: unexpected response line: %q", string(line))
 }
@@ -903,6 +929,8 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 		case bytes.HasPrefix(line, resultClientErrorPrefix):
 			errMsg := line[len(resultClientErrorPrefix) : len(line)-2]
 			return errors.New("memcache: client error: " + string(errMsg))
+		case bytes.HasPrefix(line, resultServerErrorPrefix):
+			return serverErrorFromLine(line)
 		}
 		val, err = strconv.ParseUint(string(line[:len(line)-2]), 10, 64)
 		if err != nil {

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -727,6 +727,160 @@ func TestClient_GetMulti_ContextCancelled(t *testing.T) {
 	})
 }
 
+func TestServerError_KeepsConnectionOpen(t *testing.T) {
+	// countFreeConns returns the number of connections in the client's free pool.
+	countFreeConns := func(c *Client) int {
+		c.lk.Lock()
+		defer c.lk.Unlock()
+		return len(c.freeconn[dummyAddr{}.String()])
+	}
+
+	// assertReusable verifies that the connection went back to the free pool and
+	// that a subsequent request over the very same connection still works.
+	assertReusable := func(t *testing.T, c *Client, srvw io.Writer, srvReqs <-chan string) {
+		t.Helper()
+
+		if got := countFreeConns(c); got != 1 {
+			t.Fatalf("free conns after SERVER_ERROR: got %d, want 1", got)
+		}
+
+		errCh := make(chan error)
+		go func() {
+			_, err := c.Get("foo")
+			errCh <- err
+		}()
+
+		if req := <-srvReqs; req != "gets foo\r\n" {
+			t.Fatalf("unexpected follow-up request: %q", req)
+		}
+		if _, err := io.WriteString(srvw, "END\r\n"); err != nil {
+			t.Fatalf("write follow-up response: %v", err)
+		}
+
+		if err := <-errCh; !errors.Is(err, ErrCacheMiss) {
+			t.Fatalf("follow-up Get on reused connection: got err=%v, want ErrCacheMiss", err)
+		}
+	}
+
+	t.Run("Set", func(t *testing.T) {
+		c, srvw, srvReqs := getClientWithFakeServer(t)
+
+		errCh := make(chan error)
+		go func() {
+			errCh <- c.Set(&Item{Key: "foo", Value: []byte("hello")})
+		}()
+
+		if req := <-srvReqs; req != "set foo 0 0 5\r\n" {
+			t.Fatalf("unexpected request: %q", req)
+		}
+		<-srvReqs // data block
+		if _, err := io.WriteString(srvw, "SERVER_ERROR object too large for cache\r\n"); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+
+		err := <-errCh
+		if !errors.Is(err, ErrServerError) {
+			t.Fatalf("Set: got err=%v, want ErrServerError", err)
+		}
+		if want := "memcache: server error: object too large for cache"; err.Error() != want {
+			t.Fatalf("Set: got err=%q, want %q", err.Error(), want)
+		}
+
+		assertReusable(t, c, srvw, srvReqs)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		c, srvw, srvReqs := getClientWithFakeServer(t)
+
+		errCh := make(chan error)
+		go func() {
+			_, err := c.Get("foo")
+			errCh <- err
+		}()
+
+		if req := <-srvReqs; req != "gets foo\r\n" {
+			t.Fatalf("unexpected request: %q", req)
+		}
+		if _, err := io.WriteString(srvw, "SERVER_ERROR out of memory writing get response\r\n"); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+
+		if err := <-errCh; !errors.Is(err, ErrServerError) {
+			t.Fatalf("Get: got err=%v, want ErrServerError", err)
+		}
+
+		assertReusable(t, c, srvw, srvReqs)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		c, srvw, srvReqs := getClientWithFakeServer(t)
+
+		errCh := make(chan error)
+		go func() {
+			errCh <- c.Delete("foo")
+		}()
+
+		if req := <-srvReqs; req != "delete foo\r\n" {
+			t.Fatalf("unexpected request: %q", req)
+		}
+		if _, err := io.WriteString(srvw, "SERVER_ERROR temporary failure\r\n"); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+
+		if err := <-errCh; !errors.Is(err, ErrServerError) {
+			t.Fatalf("Delete: got err=%v, want ErrServerError", err)
+		}
+
+		assertReusable(t, c, srvw, srvReqs)
+	})
+
+	t.Run("Increment", func(t *testing.T) {
+		c, srvw, srvReqs := getClientWithFakeServer(t)
+
+		errCh := make(chan error)
+		go func() {
+			_, err := c.Increment("foo", 1)
+			errCh <- err
+		}()
+
+		if req := <-srvReqs; req != "incr foo 1\r\n" {
+			t.Fatalf("unexpected request: %q", req)
+		}
+		if _, err := io.WriteString(srvw, "SERVER_ERROR temporary failure\r\n"); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+
+		if err := <-errCh; !errors.Is(err, ErrServerError) {
+			t.Fatalf("Increment: got err=%v, want ErrServerError", err)
+		}
+
+		assertReusable(t, c, srvw, srvReqs)
+	})
+
+	t.Run("non-protocol errors still close the connection", func(t *testing.T) {
+		c, srvw, srvReqs := getClientWithFakeServer(t)
+
+		errCh := make(chan error)
+		go func() {
+			errCh <- c.Set(&Item{Key: "foo", Value: []byte("hello")})
+		}()
+
+		<-srvReqs // command line
+		<-srvReqs // data block
+		if _, err := io.WriteString(srvw, "BOGUS RESPONSE\r\n"); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+
+		err := <-errCh
+		if err == nil || errors.Is(err, ErrServerError) {
+			t.Fatalf("Set: got err=%v, want a non-ErrServerError error", err)
+		}
+		if got := countFreeConns(c); got != 0 {
+			t.Fatalf("free conns after unexpected response: got %d, want 0", got)
+		}
+	})
+}
+
 // getClientWithFakeServer creates a new client, whose dial function is bound to an in-memory synchronous server.
 func getClientWithFakeServer(t *testing.T) (*Client, io.Writer, <-chan string) {
 	cliConn, srvConn := net.Pipe()


### PR DESCRIPTION
### Summary

A `SERVER_ERROR <msg>\r\n` reply is a complete, well-formed protocol line: the server keeps the connection open and in sync (it even swallows the data block on storage errors). Closing our side causes needless reconnect churn, e.g. on `object too large for cache` or OOM bursts — the worst possible time to add TCP handshake load, since the server is already under memory pressure.

### Why this is safe: memcached keeps the connection open on these errors

Verified against memcached 1.6.31 source. For the ASCII protocol (the only one this client speaks), every common `SERVER_ERROR` is written with `out_string()`, which transitions to `conn_new_cmd` — it does not close the connection. On storage errors the server additionally swallows the in-flight data block, so both sides stay in sync:

- `SERVER_ERROR object too large for cache` / `SERVER_ERROR out of memory storing object` — replies, then swallows the data block and continues:
  [proto_text.c#L2045-L2063](https://github.com/memcached/memcached/blob/1.6.31/proto_text.c#L2045-L2063)
  ```c
  out_of_memory(c, "SERVER_ERROR out of memory storing object");
  ...
  /* swallow the data line */
  conn_set_state(c, conn_swallow);
  c->sbytes = vlen;
  ```
- `SERVER_ERROR Out of memory during read` (chunk alloc failure mid-read of a set payload) — same swallow pattern:
  [memcached.c#L3240-L3250](https://github.com/memcached/memcached/blob/1.6.31/memcached.c#L3240-L3250)
- `SERVER_ERROR out of memory writing get response` — get requests carry no data block, so the connection is already in sync; the server just replies and moves on:
  [proto_text.c#L702-L713](https://github.com/memcached/memcached/blob/1.6.31/proto_text.c#L702-L713)
- `out_of_memory()` for ASCII clients is just `out_string()` ([memcached.c#L1300-L1313](https://github.com/memcached/memcached/blob/1.6.31/memcached.c#L1300-L1313)); the `conn_closing` behavior lives only in the binary-protocol branch, which this client never uses.

**Known exception:** `SERVER_ERROR out of memory reading request` (failed read-buffer realloc on a huge multiget) sets `close_after_write = true` ([memcached.c#L2494-L2496](https://github.com/memcached/memcached/blob/1.6.31/memcached.c#L2494-L2496)). If such a connection is pooled, the next request fails with EOF and the connection is then discarded as non-resumable — the same bounded, one-request cost as the pre-existing stale-pooled-connection races (server restarts, server-side idle timeouts) that the client already tolerates. Severe OOMs where memcached can't even allocate a response object close the connection without writing any error line, so the client sees a read error, not `SERVER_ERROR`, and the connection is dropped as before.

Note: error text for these responses changes from `memcache: unexpected response line...` to `memcache: server error: <msg>`.
